### PR TITLE
feat: Add 'v' prefix to Git tags

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: 'Breaking Changes'
     labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,9 @@ jobs:
       - name: Update package.json
         run: |
           $packageJson = Get-Content -Path $env:PACKAGE_JSON_PATH -Raw | ConvertFrom-Json
-          $packageJson.version = $env:VERSION
+          # Remove 'v' prefix from version for package.json
+          $versionWithoutV = $env:VERSION -replace '^v', ''
+          $packageJson.version = $versionWithoutV
           $packageJson | ConvertTo-Json -Depth 100 | Set-Content -Path $env:PACKAGE_JSON_PATH
       - name: Commit package.json
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
@@ -170,7 +172,9 @@ jobs:
         run: |
           $packageJson = Get-Content -Path $env:PACKAGE_JSON_PATH -Raw | ConvertFrom-Json
           $packageVersion = $packageJson.version
-          if ($packageVersion -ne $env:VERSION) {
+          # Compare without 'v' prefix
+          $versionWithoutV = $env:VERSION -replace '^v', ''
+          if ($packageVersion -ne $versionWithoutV) {
             Write-Error "version in package.json ($packageVersion) does not match the release draft tag ($env:VERSION)"
             exit 1
           }
@@ -182,13 +186,15 @@ jobs:
       - name: Get semver
         id: get-semver
         run: |
-          if ($env:VERSION -match '^(\d+)\.(\d+)\.(\d+)') {
+          # Parse version with or without 'v' prefix
+          if ($env:VERSION -match '^v?(\d+)\.(\d+)\.(\d+)') {
             $major = $matches[1]
             $minor = $matches[2]
             $patch = $matches[3]
-            "major=$major" | Add-Content -Path $env:GITHUB_OUTPUT
-            "minor=$major.$minor" | Add-Content -Path $env:GITHUB_OUTPUT
-            "patch=$major.$minor.$patch" | Add-Content -Path $env:GITHUB_OUTPUT
+            # Add 'v' prefix to tags
+            "major=v$major" | Add-Content -Path $env:GITHUB_OUTPUT
+            "minor=v$major.$minor" | Add-Content -Path $env:GITHUB_OUTPUT
+            "patch=v$major.$minor.$patch" | Add-Content -Path $env:GITHUB_OUTPUT
           } else {
             Write-Error "Unable to parse version: $env:VERSION"
             exit 1
@@ -197,14 +203,14 @@ jobs:
         with:
           ref: ${{ env.VERSION }}
       - name: Update major tag
-        if: ${{ steps.get-semver.outputs.major != '0' }}
+        if: ${{ steps.get-semver.outputs.major != 'v0' }}
         env:
           MAJOR_TAG: ${{ steps.get-semver.outputs.major }}
         run: |
           $refspec = "refs/tags/${env:VERSION}:refs/tags/${env:MAJOR_TAG}"
           git push -f origin $refspec
       - name: Update minor tag
-        if: ${{ steps.get-semver.outputs.minor != '0.0' }}
+        if: ${{ steps.get-semver.outputs.minor != 'v0.0' }}
         env:
           MINOR_TAG: ${{ steps.get-semver.outputs.minor }}
         run: |


### PR DESCRIPTION
## Summary
This PR adds the 'v' prefix to Git tags following semantic versioning conventions, similar to the changes made in [typescript-action PR #37](https://github.com/VeyronSakai/typescript-action/pull/37).

## Changes
- 🏷️ Update release-drafter.yml to add 'v' prefix to tag and release names
- 🔧 Update release.yml workflow to handle 'v' prefix properly:
  - Remove 'v' prefix when updating package.json version
  - Update version validation logic to compare without prefix  
  - Update semver parsing and tag creation to support 'v' prefix

## Behavior
- **Git tags**: Format like `v1.2.3`, `v2.0.0`
- **package.json**: Format like `1.2.3`, `2.0.0` (without 'v')
- Major/minor tags also with 'v' prefix (e.g., `v1`, `v1.0`)

## Testing
- [ ] Release draft correctly creates tags with 'v' prefix
- [ ] package.json version updates without 'v'
- [ ] Version validation during release works correctly