### PR TITLE
Fix release workflow authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          persist-credentials: true
       - name: Update package.json
         run: |
           $packageJson = Get-Content -Path $env:PACKAGE_JSON_PATH -Raw | ConvertFrom-Json
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: main
-          persist-credentials: false
+          persist-credentials: true
       - name: Validate version in package.json
         run: |
           $packageJson = Get-Content -Path $env:PACKAGE_JSON_PATH -Raw | ConvertFrom-Json
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ env.VERSION }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Update major tag
         if: ${{ steps.get-semver.outputs.major != 'v0' }}
         env:


### PR DESCRIPTION
## Summary

This PR fixes the authentication issue in the release workflow that was causing failures during the update-files job.

## Changes

- Changed `persist-credentials` from `false` to `true` in checkout actions
- Removed GitHub App Token generation and usage 
- Simplified authentication to use standard GITHUB_TOKEN
- Removed complex git remote URL manipulation

## Background

The previous implementation attempted to use GitHub App tokens with `persist-credentials: false`, but this created authentication issues when committing and pushing changes. Using `persist-credentials: true` is simpler and more reliable for this use case.

## Testing

This should resolve the authentication errors seen in workflow run: https://github.com/VeyronSakai/qr-code-generator/actions/runs/17540657440