### PR TITLE
Fix workflow authentication and bot exclusion

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Exclude Dependabot PRs to avoid OIDC authentication errors
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Exclude bot PRs to avoid OIDC authentication errors
+    if: ${{ !endsWith(github.actor, '[bot]') }}
 
     # Optional: Filter by PR author
     # if: |


### PR DESCRIPTION
## Summary

This PR includes fixes for both release workflow authentication and Claude Code Review bot exclusion.

## Changes

### Release Workflow Authentication Fix
- Changed `persist-credentials` from `false` to `true` in checkout actions
- Removed GitHub App Token generation and usage 
- Simplified authentication to use standard GITHUB_TOKEN
- Removed complex git remote URL manipulation

### Claude Code Review Bot Exclusion
- Updated bot exclusion condition to use `!endsWith(github.actor, '[bot]')`
- Now excludes all bot accounts including dependabot[bot], veyronsakai-app[bot], etc.
- Simplified and more generic condition

## Background

1. The release workflow was failing due to authentication issues when using `persist-credentials: false` with GitHub App tokens
2. Claude Code Review was running on bot-created PRs, which is unnecessary and can cause issues

## Testing

This should resolve:
- Authentication errors in release workflow runs
- Unnecessary Claude Code Review executions on bot PRs